### PR TITLE
Add construction tests

### DIFF
--- a/test/construction.cpp
+++ b/test/construction.cpp
@@ -1,0 +1,62 @@
+#include <cstddef>
+#include <cstdint>
+#include <cassert>
+#include <iostream>
+#include "saturating/types.hpp"
+
+using std::cerr;
+
+void test_no_overflow_on_unsigned_construction() {
+    uint_sat8_t s = 256;
+    
+    constexpr auto expected = 255;
+    
+    if (expected != s)
+    {
+        cerr << "failed. expected = " << expected << ", actual = " << +s << "\n";
+        assert(false);
+    } 
+}
+
+void test_no_underflow_on_unsigned_construction() {
+    uint_sat8_t s = -1;
+    
+    constexpr auto expected = 0;
+    
+    if (expected != s)
+    {
+        cerr << "failed. expected = " << expected << ", actual = " << +s << "\n";
+        assert(false);
+    } 
+}
+
+void test_no_overflow_on_signed_construction() {
+    int_sat8_t s = 129;
+    
+    constexpr auto expected = 127;
+    
+    if (expected != s)
+    {
+        cerr << "failed. expected = " << expected << ", actual = " << +s << "\n";
+        assert(false);
+    } 
+}
+
+void test_no_underflow_on_signed_construction() {
+    int_sat8_t s = -129;
+    
+    constexpr auto expected = -128;
+    
+    if (expected != s)
+    {
+        cerr << "failed. expected = " << expected << ", actual = " << +s << "\n";
+        assert(false);
+    } 
+}
+
+int main () {
+    test_no_overflow_on_unsigned_construction();
+    test_no_underflow_on_unsigned_construction();
+    test_no_overflow_on_signed_construction();
+    test_no_underflow_on_signed_construction();
+}

--- a/types.hpp
+++ b/types.hpp
@@ -54,8 +54,15 @@ namespace saturating {
 
         /** Create a new zero-initialized saturated type. */
         constexpr type() noexcept : value{0} {}
-
-        constexpr type(const value_type& val) noexcept : value{val} {}
+        
+        template <typename U>
+        constexpr type(const U& val) noexcept
+            : value{
+                MAX < val ? MAX :
+                val < MIN ? MIN :
+                            static_cast<value_type>(val)
+              }
+        {}
 
         /**
          * Create a new saturating type based on a given value.


### PR DESCRIPTION
This handles the scenario in which the user tries to initialize a saturating type with an out-of-range value.